### PR TITLE
Merging new release into main

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -791,12 +791,6 @@ log(data);
 
 // Set default consent mode state(s)
 const setDefault = () => {
-  // log(data.defaultSettings);
-  // data.defaultSettings.forEach(settings => {
-  //   const defaultData = parseCommandData(settings);
-  //   defaultData.wait_for_update = 500;
-  //   setDefaultConsentState(defaultData);
-  // });
   const defaultSettings = {};
   defaultSettings.analytics_storage = data.analyticsStorageDefault;
   defaultSettings.ad_storage = data.adStorageDefault;
@@ -830,18 +824,10 @@ const checkCookie = () => {
     Object.entries(settingsObj).forEach(entry => {
       const categoryName = entry[0] || '';
       const consentState = entry[1] === 'accepted' ? 'granted' : 'denied';
-      const storages = categoryDefinitions[entry[0]].split(',');
+      const storages = categoryDefinitions.hasOwnProperty(entry[0]) ? categoryDefinitions[entry[0]].split(',') : [];
       storages.forEach(storage => { updateObj[storage] = consentState; });
     });
     updateConsentState(updateObj);
-    /*
-    updateConsentState({
-      'analytics_storage': settingsObj.analytics === 'accepted' ? 'granted' : 'denied',
-      'ad_storage': settingsObj.marketing === 'accepted' ? 'granted' : 'denied',
-      'ad_user_data': settingsObj.marketing === 'accepted' ? 'granted' : 'denied',
-      'ad_personalization': settingsObj.marketing === 'accepted' ? 'granted' : 'denied',
-    });
-    */
   }
 };
 
@@ -897,17 +883,6 @@ const onFailure = () => {
 const onUserConsent = (consent, state) => {
   log(consent);
   log(state);
-  /*
-  if (!!consent && consent.indexOf('analytics_storage') > -1) {
-    if ((isConsentGranted('analytics_storage') && state === 'granted') || (!isConsentGranted('analytics_storage') && state === 'denied')) {
-      return;
-    }
-  } else if (!!consent && consent.indexOf('ad_storage') > -1) {
-    if ((isConsentGranted('ad_storage') && state === 'granted') || (!isConsentGranted('ad_storage') && state === 'denied')) {
-      return;
-    }
-  }
-  */
   
   let consentStateChangeDetected = 0;
   if (!!consent && consent.length > 0) {
@@ -986,35 +961,11 @@ let config = {
   },
   necessaryCookies: splitInput(data.necessaryCookies),
   optionalCookies: optionalCookieCategories(data.optionalCookies),
-  /*
-  optionalCookies: [{
-    name: 'analytics',
-    label: data.analyticsLabel ? data.analyticsLabel : 'Analytical Cookies',
-    description: data.analyticsDescription ? data.analyticsDescription: 'Analytical cookies help us to improve our website by collecting and reporting information on its usage.',
-    cookies: splitInput(data.analyticsCookies),
-    onAccept: function () {
-      onUserConsent(['analytics_storage'], 'granted');
-    },
-    onRevoke: function () {
-      onUserConsent(['analytics_storage'], 'denied');
-    }
-  },{
-    name: 'marketing',
-    label: data.marketingLabel ? data.marketingLabel : 'Marketing Cookies',
-    description: data.marketingDescription ? data.marketingDescription : 'We use marketing cookies to help us improve the relevancy of advertising campaigns you receive.',
-    cookies: splitInput(data.marketingCookies),
-    onAccept: function () {
-      onUserConsent(['ad_storage', 'ad_user_data', 'ad_personalization'], 'granted');
-    },
-    onRevoke: function () {
-      onUserConsent(['ad_storage', 'ad_user_data', 'ad_personalization'], 'denied');
-    },
-  }],
-  */
 };
 
 // Set banner initial state in config dependent on URL pathname
-if (getUrl('path') == '/privacy-policy/') {
+log(data.privacyURL);
+if (getUrl('path') == data.privacyURL) {
   config.initialState = 'closed';
 } else {
   config.initialState = 'open';
@@ -1642,7 +1593,7 @@ scenarios:
 - name: updateConsentState test
   code: |-
     // Simulate getCookieValues function call result
-    mock('getCookieValues', ['{"necessaryCookies":[],"optionalCookies":{"analytics_cookies":"accepted","marketing_cookies":"accepted","test":"accepted"},"statement":{"shown":true,"updated":"10/02/2022"},"consentDate":1703174608142,"consentExpiry":90,"interactedWith":true,"user":"C411DC12-1A6D-4F2B-9A52-883A58616A00"}']);
+    mock('getCookieValues', ['{"necessaryCookies":[],"optionalCookies":{"analytical_cookies":"accepted","marketing_cookies":"accepted","test":"accepted"},"statement":{"shown":true,"updated":"10/02/2022"},"consentDate":1703174608142,"consentExpiry":90,"interactedWith":true,"user":"C411DC12-1A6D-4F2B-9A52-883A58616A00"}']);
 
     // Call runCode to run the template's code.
     runCode(mockData);
@@ -1669,9 +1620,10 @@ setup: |-
     urlPassthrough: true,
     adsDataRedaction: true,
     optionalCookies:[
-      {"optCatLabel":"Analytics Cookies","optCatDescription":"asdasd","optCatCookies":"asdasd","storage":"analytics_storage"},
-      {"optCatLabel":"Marketing Cookies","optCatDescription":"bbbbbbbbb","optCatCookies":"bbbbbbb","storage":"ad_storage,ad_user_data,ad_personalization"},
-      {"optCatLabel":"Test","optCatDescription":"ccccccccccccc","optCatCookies":"cccccccccc","storage":"security_storage"}],
+      {"optCatLabel":"Analytical Cookies","optCatDescription":"Analytical cookies help us to improve our website by collecting and reporting information on its usage.","optCatCookies":"a,b,c","storage":"analytics_storage"},
+      {"optCatLabel":"Marketing Cookies","optCatDescription":"We use marketing cookies to help us improve the relevancy of advertising campaigns you receive.","optCatCookies":"d,e,f","storage":"ad_storage,ad_user_data,ad_personalization"},
+      {"optCatLabel":"Test","optCatDescription":"test category","optCatCookies":"g,h,i","storage":"security_storage"}
+    ],
   };
 
 

--- a/template.tpl
+++ b/template.tpl
@@ -253,33 +253,45 @@ ___TEMPLATE_PARAMETERS___
         "displayName": "Optional Cookies"
       },
       {
-        "type": "SIMPLE_TABLE",
+        "type": "PARAM_TABLE",
         "name": "optionalCookies",
         "displayName": "Optional Cookie Categories",
-        "simpleTableColumns": [
+        "paramTableColumns": [
           {
-            "defaultValue": "",
-            "displayName": "Label",
-            "name": "optCatLabel",
-            "type": "TEXT"
+            "param": {
+              "type": "TEXT",
+              "name": "optCatLabel",
+              "displayName": "Label",
+              "simpleValueType": true
+            },
+            "isUnique": true
           },
           {
-            "defaultValue": "",
-            "displayName": "Description",
-            "name": "optCatDescription",
-            "type": "TEXT"
+            "param": {
+              "type": "TEXT",
+              "name": "optCatDescription",
+              "displayName": "Description",
+              "simpleValueType": true
+            },
+            "isUnique": true
           },
           {
-            "defaultValue": "",
-            "displayName": "Cookies",
-            "name": "optCatCookies",
-            "type": "TEXT"
+            "param": {
+              "type": "TEXT",
+              "name": "optCatCookies",
+              "displayName": "Cookies",
+              "simpleValueType": true
+            },
+            "isUnique": false
           },
           {
-            "defaultValue": "",
-            "displayName": "Storage",
-            "name": "storage",
-            "type": "TEXT"
+            "param": {
+              "type": "TEXT",
+              "name": "storage",
+              "displayName": "Storage",
+              "simpleValueType": true
+            },
+            "isUnique": false
           }
         ]
       }
@@ -717,6 +729,13 @@ ___TEMPLATE_PARAMETERS___
         "simpleValueType": true,
         "defaultValue": false
       }
+    ],
+    "enablingConditions": [
+      {
+        "paramName": "product",
+        "paramValue": "COMMUNITY",
+        "type": "NOT_EQUALS"
+      }
     ]
   },
   {
@@ -878,6 +897,7 @@ const onFailure = () => {
 const onUserConsent = (consent, state) => {
   log(consent);
   log(state);
+  /*
   if (!!consent && consent.indexOf('analytics_storage') > -1) {
     if ((isConsentGranted('analytics_storage') && state === 'granted') || (!isConsentGranted('analytics_storage') && state === 'denied')) {
       return;
@@ -886,6 +906,20 @@ const onUserConsent = (consent, state) => {
     if ((isConsentGranted('ad_storage') && state === 'granted') || (!isConsentGranted('ad_storage') && state === 'denied')) {
       return;
     }
+  }
+  */
+  
+  let consentStateChangeDetected = 0;
+  if (!!consent && consent.length > 0) {
+    for (let i = 0; i < consent.length; i++) {
+      if ((!isConsentGranted(consent[i]) && state === 'granted') || (isConsentGranted(consent[i]) && state === 'denied')) {
+        consentStateChangeDetected++;
+      }
+    }
+  }
+  
+  if (consentStateChangeDetected === 0) {
+    return;
   }
   
   let consentModeStates = {};


### PR DESCRIPTION
Consent Mode Settings overhauled
- Includes Consent Mode V2 storage types `ad_user_data` and `ad_personalization`
- `analytics_storage`, `ad_storage`, `ad_user_data` and `ad_personalization` are set via a dropdown and must have values
- Additional storage types are set in two additional text fields (granted and denied)
    - This is to incorporate any new future storage types that may appear
- `region` option removed (may be reintroduced later) so that the new consent fields can work

Cookie Categories
- Added a text field for any Necessary Cookies that Cookie Control should preserve
- Optional Cookie Categories are no longer restricted to "Analytics" and "Marketing", instead any number of categories can be created and assigned cookie names and any consent storage types
- Categories are added via a parameter table

Tests
- Two tests are included for checking `setDefaultConsentState` and `updateConsentState` methods

Functionality
- The `consentUpdate` data layer event will only be pushed if the particular consent type has exhibited an actual state change (e.g. if `analytics_storage` is already `granted` and Accept all is clicked, no data layer event is sent)
- The "Branding" section is only visible in the template UI if the "Product" value does not equal "Community"